### PR TITLE
Enables styling on Wordpress menus

### DIFF
--- a/src/scss/_menus.scss
+++ b/src/scss/_menus.scss
@@ -3,7 +3,7 @@
 // Inline menu; used in header and footer navigation
 .menu-inline {
   @extend %clearfix;
-  ul {
+  &, ul {
     list-style-type: none;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
The inline styling currently only works for the default menus