### PR TITLE
Small fixes

### DIFF
--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -112,7 +112,7 @@ module.exports = {
     clean: [build+'**/.DS_Store'] // A glob matching junk files to clean out of `build`
   , wipe: [dist] // Clean this out before creating a new distribution copy
   , dist: {
-      src: [build+'**/*', '!'+build+'**/*.min.css']
+      src: [build+'**/*', '!'+build+'**/*.min.css*']
     , dest: dist
     }
   },

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -80,7 +80,6 @@ module.exports = {
     }
   , dist: {
       src: [dist+'**/*.css', '!'+dist+'**/*.min.css']
-    , minify: { keepSpecialComments: 1, roundingPrecision: 3 }
     , dest: dist
     }
   , compiler: 'libsass' // Choose a Sass compiler: 'libsass' or 'ruby-sass'

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -94,6 +94,9 @@ module.exports = {
   , libsass: { // Requires the libsass implementation of Sass
       includePaths: [bower] // Adds the `bower_components` directory to the load path so you can @import directly
     , precision: 6
+    , onError: function(err) {
+        return console.log(err);
+      }
     }
   },
 


### PR DESCRIPTION
* Removed some (duplicate) code that's not used.
* Added wildcard to source selector so that style.min.css.map won't get copied to the dist folder. We don't need it there.
* The gulp watch task stops when Sass finds an error. To keep the workflow going I added something to catch the error but keep gulp watch running.