### PR TITLE
Add missing jshint as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-cssnano": "^2.1.2",
     "gulp-imagemin": "^3.0.3",
     "gulp-jshint": "^2.0.1",
+    "jshint": "^2.9.3",
     "gulp-livereload": "^3.8.1",
     "gulp-load-plugins": "^1.2.4",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Gulp was complaining of missing jshint.

I think that solves it.
